### PR TITLE
Dont highlight unknown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Prism.languages.json = {
 }
 ```
 
+### Options
+
+Options are optional.
+
+* **json**: JSON highlighting definition for Prism.
+
 ## Language support
 
 Supports all programming languages that have a corresponding Prism.js component file. Component files are found in the [Prism.js `components` directory](https://github.com/PrismJS/prism/tree/master/components).

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,8 @@ module.exports = function(options) {
       $('code').each(function() {
 
         var $this = $(this);
-        var className = $this.attr('class');
-
-        var targets = className ? className.split('language-') : ['', 'markup'];
+        var className = $this.attr('class') || '';
+        var targets = className.split('language-');
 
         if(targets.length > 1) {
           highlighted = true;

--- a/tests/fixtures/markup/expected/unknown.html
+++ b/tests/fixtures/markup/expected/unknown.html
@@ -1,0 +1,1 @@
+<code>{[&apos;foo&apos;+&apos;bar&apos;]:&apos;bam&apos;}</code>

--- a/tests/fixtures/markup/src/unknown.html
+++ b/tests/fixtures/markup/src/unknown.html
@@ -1,0 +1,1 @@
+<code>{[&apos;foo&apos;+&apos;bar&apos;]:&apos;bam&apos;}</code>

--- a/tests/index.js
+++ b/tests/index.js
@@ -36,4 +36,22 @@ describe('metalsmith-prism', function() {
       });
 
   });
+
+  it ('should not highlight unknown language code blocks', function(done) {
+
+    var metal = metalsmith(fixture());
+
+    metal
+      .use(metalsmithPrism())
+      .build(function(err){
+
+        if(err) {
+          return done(err);
+        }
+
+        expect(file('build/unknown.html')).to.be.eql(file('expected/unknown.html'));
+
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Hi!

I'm trying to fix a double escaping issue I've got with inline codespans in markdown posts. An illustration of what I've found is happening in my use case:

```
`{['foo'+'bar']:'bam'}`

|
v

(markdown middleware)

|
v

<code>{[&apos;foo&apos;+&apos;bar&apos;]:&apos;bam&apos;}</code>

|
v

(prism middleware)

|
v

<code>{[<span class="token entity" title="&apos;">&amp;apos;</span>foo<span class="token entity" title="&apos;">&amp;apos;</span>+<span class="token entity" title="&apos;">&amp;apos;</span>bar<span class="token entity" title="&apos;">&amp;apos;</span>]:<span class="token entity" title="&apos;">&amp;apos;</span>bam<span class="token entity" title="&apos;">&amp;apos;</span>}</code>
```

After some digging I found this package decided to highlight the code blocks without language specified, as `markup`. I found the best solution in my case was simply not to highlight these code blocks at all.

Any thoughts?