### PR TITLE
Pre classname

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,16 +42,6 @@ module.exports = (options) => {
       }
     }
 
-    function addLineNumber($el) {
-
-      const $parent = $el.parent();
-      if ($parent && $parent.is('pre')) {
-        debug('adding line numbers');
-        $parent.addClass('line-numbers');
-      }
-
-    }
-
     _.each(files, (file, name) => {
 
       // gulpsmith || vanilla Metalsmith support
@@ -71,8 +61,16 @@ module.exports = (options) => {
 
         if (targets.length > 1) {
 
-          if (options.lineNumbers) {
-            addLineNumber($this);
+          const $pre = $this.parent('pre');
+
+          if ($pre) {
+            // Copy className to <pre> container
+            $pre.addClass(className);
+
+            if (options.lineNumbers) {
+              debug('adding line numbers');
+              $pre.addClass('line-numbers');
+            }
           }
 
           highlighted = true;

--- a/tests/fixtures/markup/expected/pre-classname.html
+++ b/tests/fixtures/markup/expected/pre-classname.html
@@ -1,4 +1,4 @@
-<pre class="language-javascript line-numbers">
+<pre class="language-javascript">
   <code class="language-javascript">
     <span class="token keyword">var</span> name <span class="token operator">=</span> <span class="token string">&quot;Rob&quot;</span><span class="token punctuation">;</span>
   </code>

--- a/tests/index.js
+++ b/tests/index.js
@@ -78,6 +78,25 @@ describe('metalsmith-prism', () => {
 
   });
 
+  it('should add language class to <pre> tag', function(done) {
+
+    const metal = metalsmith(fixture());
+
+    metal
+      .use(metalsmithPrism())
+      .build( err => {
+
+        if (err) {
+          return done(err);
+        }
+
+        expect(file('build/line-numbers.html')).to.be.eql(file('expected/pre-classname.html'));
+
+        done();
+      });
+
+  });
+
   it('should add line numbers class to <pre> tag when options#lineNumbers is true', function(done) {
 
     const metal = metalsmith(fixture());


### PR DESCRIPTION
Hi there,

I'd like to submit that merge request in order to manage `<pre>` container classname.

Here is an example of the expected behavior:

Entry:
```
<pre>
  <code class="language-javascript">
    some content…
  </code>
</pre>
```

Result:
```
<pre class="language-javascript">
  <code class="language-javascript">
    some content…
  </code>
</pre>
```

Without that behavior, default styles/CSS won't match. 