### PR TITLE
move debug to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/Availity/metalsmith-prism",
   "dependencies": {
     "cheerio": "0.22.0",
+    "debug": "2.2.0",
     "he": "1.1.0",
     "lodash": "4.15.0",
     "metalsmith": "2.2.0",
@@ -41,7 +42,6 @@
   "devDependencies": {
     "babel-eslint": "6.1.2",
     "chai": "3.5.0",
-    "debug": "^2.2.0",
     "eslint": "3.3.1",
     "eslint-config-availity": "2.0.0-beta.11",
     "mocha": "3.0.2"


### PR DESCRIPTION
Right now an error is thrown if `metalsmith-prism` is installed with the `NODE_ENV` variable set to `production` or as a dependency of another project. In these cases, in fact, the [`debug`](https://github.com/Availity/metalsmith-prism/blob/203e9f611500bb1643cadd09a3a6603e7cd8c0cd/lib/index.js#L4) dependency is not installed.

This patch fixes the issue by moving `debug` from `devDependencies` to `dependencies`.