### PR TITLE
Check file key for html extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ module.exports = (options) => {
     _.each(files, (file, name) => {
 
       // gulpsmith || vanilla Metalsmith support
-      if (!isHTMLFile(file.path || name)) {
+      if (!isHTMLFile(file.path || name) && !isHTMLFile(name)) {
         return;
       }
 


### PR DESCRIPTION
[metalsmith-markdown](https://github.com/segmentio/metalsmith-markdown) doesn't modify `file.path` to reflect the filetype change, rather it deletes the old file and adds a new one with the updated extension ([L43-L44](https://github.com/segmentio/metalsmith-markdown/blob/master/lib/index.js#L43-L44)) to the files array. I added an additional condition to check the file key for the `.html` extension. 

