### PR TITLE
Pre-load language component(s) passed in as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ Metalsmith(__dirname)
   }))
 ```
 
+#### preLoad (optional)
+
+- Pre-loads language component(s), such that each language component registers itself in the order given in the input array
+- Useful for loading syntax that extends other language components that are not automatically registered by Prism
+
+```javascript
+Metalsmith(__dirname)
+  .use(metalsmithPrism({
+    preLoad: ["java", "scala"]
+  }))
+```
+
 ## Authors
 
 **Robert McGuinness**

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,18 @@ module.exports = (options) => {
 
   options = options || {};
 
+  if (options.preLoad) {
+    _.each(options.preLoad, (language) => {
+      try {
+        require(`prismjs/components/prism-${language}.js`);
+      } catch (e) {
+        /* eslint no-console: 0 */
+        console.warn(`Failed to load prism syntax: ${language}`);
+        console.warn(e);
+      }
+    });
+  }
+
   return function(files, metalsmith, done) {
 
     setImmediate(done);

--- a/tests/fixtures/markup/expected/scala.html
+++ b/tests/fixtures/markup/expected/scala.html
@@ -1,0 +1,3 @@
+<code class="language-scala">
+  <span class="token keyword">val</span> hello<span class="token operator">:</span> <span class="token builtin">String</span> <span class="token operator">=</span> <span class="token string">&quot;Hello world!&quot;</span>
+</code>

--- a/tests/fixtures/markup/src/scala.html
+++ b/tests/fixtures/markup/src/scala.html
@@ -1,0 +1,3 @@
+<code class="language-scala">
+  val hello: String = "Hello world!"
+</code>

--- a/tests/index.js
+++ b/tests/index.js
@@ -39,6 +39,27 @@ describe('metalsmith-prism', () => {
 
   });
 
+  it('should pre-load and register language components for java, and then highlight code block for scala', done => {
+
+    const metal = metalsmith(fixture());
+
+    metal
+      .use(metalsmithPrism({
+        preLoad: ['java']
+      }))
+      .build( err => {
+
+        if (err) {
+          return done(err);
+        }
+
+        expect(file('build/scala.html')).to.be.eql(file('expected/scala.html'));
+
+        done();
+      });
+
+  });
+
   it('should NOT highlight unknown language code blocks', done => {
 
     const metal = metalsmith(fixture());


### PR DESCRIPTION
Allows using a language that is dependent on another language component that is not automatically registered by Prism. Useful for loading syntax that extends other language components that are not automatically registered by Prism (e.g., Scala is dependent on Java, as it extends Java, but Java is not automatically registered by Prism). See this [discussion](https://github.com/SamyPesse/draft-js-prism/issues/7). 